### PR TITLE
Fix Window Hash

### DIFF
--- a/lib/jquery.easytabs.js
+++ b/lib/jquery.easytabs.js
@@ -219,6 +219,8 @@
       // Cache is disabled => reload (e.g reload an ajax tab).
       } else if ( ! settings.cache ){
         activateTab($clicked, $targetPanel, ajaxUrl, callback);
+      } else {
+        skipUpdateToHash = false;
       }
 
     };


### PR DESCRIPTION
When changing the tab, the tab is displayed and the window hash is set to the new tab id.
This in turn triggers selectTabFromHashChange in easytab which sets skipUpdateToHash = True and calls plugin.selectTab.
If the tab is already displayed and active the skipUpdateToHashwhich is never cleared in the easytab code when the tab is already visible.
This leads to an incorrect hash the next time a tab is changed, it will stick with the old tab in the window hash.
The else statement clears the skipuptaehash variable in case none if the cases in selectTab are triggered.

Signed-off-by: Sven Auhagen <sven.auhagen@voleatech.de>